### PR TITLE
Remove unnecessary callback definition

### DIFF
--- a/lib/buildSearch.js
+++ b/lib/buildSearch.js
@@ -59,7 +59,6 @@ module.exports = function(outFile, cb) {
   // Write the finished results to disk
   mkdirp(path.dirname(outFile), function(err) {
     if (err) throw err;
-    if (typeof cb !== 'function') cb = function(){};
     fs.writeFile(outFile, JSON.stringify(results, null, '  '), cb);
   });
 }


### PR DESCRIPTION
This PR removes the unnecessary `cb` definition as this should be set by gulp to prevent race conditions (gulp waits for its call).